### PR TITLE
Fixed the link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ To get started, begin with the [Introduction](../../wiki/Introduction) wiki page
 Please search, join, and/or email the discussion list with questions at [cauliflowervest-discuss@googlegroups.com](https://groups.google.com/forum/#!forum/cauliflowervest-discuss).
 To reach only engineers on the project, email cauliflowervest-eng@googlegroups.com.
 
-<br />
 
-<img src='https://raw.githubusercontent.com/google/cauliflowervest/master/res/cauliflower_vest_logo.png?token=9258614__eyJzY29wZSI6IlJhd0Jsb2I6Z29vZ2xlL2NhdWxpZmxvd2VydmVzdC9tYXN0ZXIvcmVzL2NhdWxpZmxvd2VyX3Zlc3RfbG9nby5wbmciLCJleHBpcmVzIjoxNDE0MTYzOTgzfQ%3D%3D--c6b6f034a6a1476661993ac550fa35182825ba5c' />
-<p>Thanks to [Dorothy Marczak](https://plus.google.com/106286115972636321533/about) for the logo.</p>
+
+![](https://raw.githubusercontent.com/google/cauliflowervest/master/res/cauliflower_vest_logo.png?token=9258614__eyJzY29wZSI6IlJhd0Jsb2I6Z29vZ2xlL2NhdWxpZmxvd2VydmVzdC9tYXN0ZXIvcmVzL2NhdWxpZmxvd2VyX3Zlc3RfbG9nby5wbmciLCJleHBpcmVzIjoxNDE0MTYzOTgzfQ%3D%3D--c6b6f034a6a1476661993ac550fa35182825ba5c)
+
+Thanks to [Dorothy Marczak](https://plus.google.com/106286115972636321533/about) for the logo.


### PR DESCRIPTION
The part of the readme from the image down wasn't done in markdown, but in html. This resulted in the markdown link being shown as plain text. I've fixed that by moving it over to markdown.