### PR TITLE
Makefile target: npm init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,10 @@ ${CV_SDIST}: clean VE client_config
 client_config:
 	@echo client_config
 
-server_config: build test keyczar
+npm_init:
+	@if [ ! -x "package.json" ]; then npm init ; fi
+
+server_config: npm_init build test keyczar
 	./create_gae_bundle.sh ${CWD}
 
 tmp/${KEYCZAR_SRC}:

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ client_config:
 	@echo client_config
 
 npm_init:
-	@if [ ! -x "package.json" ]; then npm init ; fi
+	@if [ ! -f "package.json" ]; then npm init ; fi
 
 server_config: npm_init build test keyczar
 	./create_gae_bundle.sh ${CWD}


### PR DESCRIPTION
If package.json is not found in the root folder, run ```npm init``` to generate a ```package.json``` file. 

Without this target, ```make server_config``` fails several npm install events.